### PR TITLE
Remove carriage returns from source file text

### DIFF
--- a/kotlin-power-assert-plugin/src/main/kotlin/com/bnorm/power/PowerAssertCallTransformer.kt
+++ b/kotlin-power-assert-plugin/src/main/kotlin/com/bnorm/power/PowerAssertCallTransformer.kt
@@ -84,7 +84,7 @@ class PowerAssertCallTransformer(
 
   override fun lower(irFile: IrFile) {
     file = irFile
-    fileSource = File(irFile.path).readText()
+    fileSource = File(irFile.path).readText().replace("\r\n", "\n")
 
     irFile.transformChildrenVoid()
   }

--- a/kotlin-power-assert-plugin/src/test/kotlin/com/bnorm/power/test.kt
+++ b/kotlin-power-assert-plugin/src/test/kotlin/com/bnorm/power/test.kt
@@ -382,6 +382,23 @@ check(1 == 2) { "the world is broken" }
       PowerAssertComponentRegistrar(setOf(FqName("kotlin.check")))
     )
   }
+
+  @Test
+  fun carriageReturnRemoval() {
+    assertMessage(
+      """
+fun main() {
+  val a = 0
+  assert(a == 42)
+}""".replace("\n", "\r\n"),
+      """
+Assertion failed
+assert(a == 42)
+       | |
+       | false
+       0
+""".trimIndent())
+  }
 }
 
 fun assertMessage(
@@ -390,7 +407,7 @@ fun assertMessage(
   vararg plugins: ComponentRegistrar = arrayOf(PowerAssertComponentRegistrar(setOf(FqName("kotlin.assert"))))
 ) {
   val result = KotlinCompilation().apply {
-    sources = listOf(SourceFile.kotlin("main.kt", source))
+    sources = listOf(SourceFile.kotlin("main.kt", source, trimIndent = false))
     useIR = true
     messageOutputStream = System.out
     compilerPlugins = plugins.toList()


### PR DESCRIPTION
Fixes #20 

The Kotlin compiler removes carriage returns from the text of the file
when calculating the startOffset and endOffset properties for an
IrExpression. This causes the source snippet extraction to not work for
files with Windows-style line-separators.

Before pull substrings out of the file source string, remove all
carriages returns so the IrExpression offsets match the compiler.