### PR TITLE
Add configuration instructions in groovy to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,16 @@ The Gradle plugin allows configuring the functions which should be transformed
 with a list of fully-qualified function names.
 
 ```kotlin
+// Kotlin DSL
 configure<com.bnorm.power.PowerAssertGradleExtension> {
   functions = listOf("kotlin.assert", "kotlin.test.assertTrue")
+}
+```
+
+```groovy
+// Groovy
+kotlinPowerAssert {
+  functions = ["kotlin.assert", "kotlin.test.assertTrue"]
 }
 ```
 


### PR DESCRIPTION
Thought this would be helpful for people who're still using groovy (like me!). The name of the extension can only be found by digging inside the sources.