### PR TITLE
configure to run tests in parallel and eliminate global state

### DIFF
--- a/kotlin-power-assert-plugin/build.gradle.kts
+++ b/kotlin-power-assert-plugin/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
   testImplementation(kotlin("test-junit5"))
   testImplementation("org.jetbrains.kotlin:kotlin-compiler-embeddable")
   testImplementation("com.github.tschuchortdev:kotlin-compile-testing:1.4.9")
+  testImplementation(enforcedPlatform("org.junit:junit-bom:5.9.1"))
 }
 
 tasks.withType<KotlinCompile> {

--- a/kotlin-power-assert-plugin/src/test/kotlin/com/bnorm/power/InfixFunctionTest.kt
+++ b/kotlin-power-assert-plugin/src/test/kotlin/com/bnorm/power/InfixFunctionTest.kt
@@ -349,11 +349,11 @@ class InfixFunctionTest {
     )
   }
 
-  private fun run(file: SourceFile, fqNames: Set<FqName>): String {
+  private fun run(file: SourceFile, fqNames: Set<FqName>, main: String = "MainKt"): String {
     val result = compile(listOf(file), PowerAssertComponentRegistrar(fqNames))
     assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, "Failed with messages: " + result.messages)
 
-    val kClazz = result.classLoader.loadClass("MainKt")
+    val kClazz = result.classLoader.loadClass(main)
     val main = kClazz.declaredMethods.single { it.name == "main" && it.parameterCount == 0 }
     try {
       try {

--- a/kotlin-power-assert-plugin/src/test/kotlin/com/bnorm/power/MultiParameterFunctionTest.kt
+++ b/kotlin-power-assert-plugin/src/test/kotlin/com/bnorm/power/MultiParameterFunctionTest.kt
@@ -19,9 +19,6 @@ package com.bnorm.power
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import org.jetbrains.kotlin.name.FqName
-import java.io.ByteArrayOutputStream
-import java.io.PrintStream
-import java.lang.reflect.InvocationTargetException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -140,7 +137,7 @@ private fun executeMainDebug(mainBody: String): String {
 fun <T> dbg(key: Any, value: T): T = value
 
 fun <T> dbg(key: Any, value: T, msg: String): T {
-    println(key.toString() + "=" + value + "\n" + msg)
+    throw RuntimeException("result:"+key.toString() + "=" + value + "\n" + msg)
     return value
 }
 
@@ -156,15 +153,5 @@ fun main() {
 
   val kClazz = result.classLoader.loadClass("MainKt")
   val main = kClazz.declaredMethods.single { it.name == "main" && it.parameterCount == 0 }
-  val prevOut = System.out
-  try {
-    val out = ByteArrayOutputStream()
-    System.setOut(PrintStream(out))
-    main.invoke(null)
-    return out.toString("UTF-8")
-  } catch (t: InvocationTargetException) {
-    throw t.cause!!
-  } finally {
-    System.setOut(prevOut)
-  }
+  return getMainResult(main)
 }

--- a/kotlin-power-assert-plugin/src/test/resources/junit-platform.properties
+++ b/kotlin-power-assert-plugin/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+# suppress inspection "UnusedProperty" for whole file
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default = concurrent


### PR DESCRIPTION
this speeds up a `./gradlew cleanTest test` run from 14 seconds to 5 seconds on my m1 macbook pro. 
If you like I can also create a PR that converts the test suite to https://github.com/failgood/failgood, which will probably make it even faster, simpler and nicer to read `</commercial>`